### PR TITLE
敵レベル選択画面を追加

### DIFF
--- a/Osero/Osr001.vb
+++ b/Osero/Osr001.vb
@@ -43,7 +43,12 @@ Public Class Osr001
     Private Sub Btn_Start_Click(sender As Object, e As EventArgs) Handles Btn_Start.Click
         Try
             If game.GameStatus = Game.Status.Game_status_NoGame Then
-                game.GameStart(Enemy.EnemyIs.CPU, Enemy.Level.nakamura)
+
+                '敵レベルを選択
+                Dim selectForm As New Osr002
+                Dim enemyLV As Integer = selectForm.ShowDialog()
+
+                game.GameStart(Enemy.EnemyIs.CPU, enemyLV)
                 Btn_Start.Text = "中断する"
             Else
                 'If MessageBox.Show("途中だけど止める？", "確認", MessageBoxButtons.YesNo) = DialogResult.Yes Then

--- a/Osero/Osr002.vb
+++ b/Osero/Osr002.vb
@@ -4,25 +4,26 @@ Public Class Osr002
 
 
     Private Sub Txt_Easy_Click(sender As Object, e As EventArgs) Handles Txt_Easy.Click
-        'Me.DialogResult = Enemy.Level.easy
+        Me.DialogResult = Enemy.Level.easy
         Me.Close()
     End Sub
 
-    Private Sub Txt_Normal_TextChanged(sender As Object, e As EventArgs) Handles Txt_Normal.TextChanged
-        'Me.DialogResult = Enemy.Level.normal
-        Me.Close()
+    Private Sub Txt_Normal_TextChanged(sender As Object, e As EventArgs) Handles Txt_Normal.Click
+        Me.DialogResult = Enemy.Level.normal
+        Me.close()
     End Sub
 
-    Private Sub Txt_Hard_TextChanged(sender As Object, e As EventArgs) Handles Txt_Hard.TextChanged
-        'Me.DialogResult = Enemy.Level.hard
-        Me.Close()
+    Private Sub Txt_Hard_TextChanged(sender As Object, e As EventArgs) Handles Txt_Hard.Click
+        Me.DialogResult = Enemy.Level.hard
+        Me.close()
     End Sub
 
     Private Sub Osr002_FormClosed(sender As Object, e As FormClosedEventArgs) Handles MyBase.FormClosed
-        'Me.Dispose()
+        Me.Dispose()
     End Sub
 
     Private Sub Osr002_Load(sender As Object, e As EventArgs) Handles MyBase.Load
 
     End Sub
+
 End Class


### PR DESCRIPTION
何故か敵レベルの選択画面が表示出来ずエラーになっていたのですが、
原因はイベントのハンドル箇所でした。
「クリックした時」のイベントを取得していたつもりが
「テキストが変更になった時」のイベントを取得していました。